### PR TITLE
Respect required option

### DIFF
--- a/ampersand-select-view.js
+++ b/ampersand-select-view.js
@@ -218,7 +218,7 @@ SelectView.prototype.validate = function () {
         return element === this.value;
     }.bind(this));
 
-    if (!this.valid) {
+    if (!this.valid && this.required) {
         this.setMessage(this.requiredMessage);
     } else {
         this.setMessage();


### PR DESCRIPTION
Display _Selection required_ message only when `required` option is set to true.
