### PR TITLE
Do NOT disable string item options by default

### DIFF
--- a/ampersand-select-view.js
+++ b/ampersand-select-view.js
@@ -269,7 +269,7 @@ SelectView.prototype.getOptionDisabled = function (option) {
 
     if (this.options.isCollection && this.disabledAttribute) return option[this.disabledAttribute];
 
-    return option;
+    return false;
 };
 
 SelectView.prototype.setMessage = function (message) {

--- a/test/index.js
+++ b/test/index.js
@@ -135,6 +135,14 @@ suite('Options array with string items', function (s) {
         t.equal(select.options[select.selectedIndex].innerHTML, 'Please choose:');
 
     }));
+
+    s.test('options are enabled', sync(function (t) {
+        var optionNodes = view.el.querySelectorAll('select option');
+
+        t.equal(optionNodes[0].disabled, false);
+        t.equal(optionNodes[1].disabled, false);
+        t.equal(optionNodes[2].disabled, false);
+    }));
 });
 
 suite('Options array with array items', function (s) {


### PR DESCRIPTION
Sorry guys, I've just realised #15 introduced a bug where single string options passed in are disabled by default. Obviously this is very bad. Hopefully this can be merged ASAP.