### PR TITLE
3.0.0 RC

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,4 +1,5 @@
 {
+  "browser": true,
   "quotmark": true,
   "undef": true,
   "unused": true,

--- a/README.md
+++ b/README.md
@@ -1,19 +1,76 @@
 # ampersand-select-view
-
-Lead Maintainer: [Chris (@cdaringe)](https://github.com/cdaringe)
-
-![](https://travis-ci.org/AmpersandJS/ampersand-select-view.svg) ![](https://badge.fury.io/js/ampersand-select-view.svg)
-
 A view module for intelligently rendering and validating selectbox input. Works well with ampersand-form-view.
 
-<!-- starthide -->
-Part of the [Ampersand.js toolkit](http://ampersandjs.com) for building clientside applications.
-<!-- endhide -->
+![](https://travis-ci.org/AmpersandJS/ampersand-select-view.svg) ![](https://badge.fury.io/js/ampersand-select-view.svg)
 
 ## install
 
 ```
 npm install ampersand-select-view
+```
+
+## 4.0.0 Release Plan
+The upcoming release 4.x is intended to migrate `ampersand-select-view` to an extension of `ampersand-view`.  Due to the refactor, merging changes becomes difficult as the module will exhibit a different structure. As such, *all PRs*, including bugfixes, should be submitted by April 20, 2015!
+
+<!-- starthide -->
+Part of the [Ampersand.js toolkit](http://ampersandjs.com) for building clientside applications.
+<!-- endhide -->
+
+## API Reference
+
+### clear() - [Function] - returns `this`
+Alias to calling `setValue(null, true)`.  Sets the selected option to either the [unselectedText](#general-options) option or a user defined option whose value is `null`.  *Be mindful* that if no unselectedText or `null` option exists, the view will error.
+
+### reset() - [Function] - returns `this`
+Sets the selected option and view value to the original option value provided during construction.
+
+### setValue([value, skipValidationMessage]) - [Function] - returns `this`
+Sets the selected option to that which matches the provided value.  Updates the view's `.value` accordingly.  SelectView will error if no matching option exists.  `null, `undefined`, and `''` values will preferentially select [unselectedText](#general-options) if defined.
+
+### constructor - [Function] `new SelectView([options])`
+#### options
+##### general options
+- `name`: the `<select>`'s `name` attribute's value. Used when reporting to parent form
+- `parent`: parent form reference
+- `options`: array/collection of options to render into the select box
+- `[el]`: element if you want to render the view into
+- `[template]`: a custom template to use (see 'template' section, below, for more)
+- `[required]`: [default: `false`] field required
+- `[eagerValidate]`: [default: `false`] validate and show messages immediately.  Note: field will be validated immediately to provide a true `.valid` value, but messages by default are hidden.
+- `[unselectedText]`: text to display if unselected
+- `[value]`: initial value for the `<select>`.  `value` **must** be a member of the `options` set
+
+##### label & validation options
+- `[label]`: [default: `name` value] text to annotate your select control
+- `[invalidClass]`: [default: `'select-invalid'`] class to apply to root element if invalid
+- `[validClass]`: [default: `'select-valid'`] class to apply to root element if valid
+- `[requiredMessage]`: [default: `'Selection required'`] message to display if invalid and required
+
+##### collection option set
+If using a collection to produce `<select>` `<option>`s, the following may also be specified:
+
+- `[disabledAttribute]`: boolean model attribute to flag disabling of the option node
+- `[idAttribute]`: model attribute to use as the id for the option node.  This will be returned by `SelectView.prototype.value`
+- `[textAttribute]`: model attribute to use as the text of the option node in the select box
+- `[yieldModel]`: [default: `true`] if options is a collection, yields the full model rather than just its `idAttribute` to `.value`
+
+## custom template
+You may override the default template by providing your own template string to the [constructor](#constructor---function-new-selectviewoptions) options hash.  Technically, all you must provided is a `<select>` element.  However, your template may include the following under a single root element:
+
+1. An element with a `data-hook="label"` to annotate your select control
+1. An `<select>` element to hold your `options`
+1. An element with a `data-hook="message-container"` to contain validation messages
+1. An element with a `data-hook="message-text"` nested beneath the `data-hook="message-container"` element to show validation messages
+
+Here's the default template for reference:
+```html
+<label class="select">
+    <span data-hook="label"></span>
+    <select></select>
+    <span data-hook="message-container" class="message message-below message-error">
+        <p data-hook="message-text"></p>
+    </span>
+</label>
 ```
 
 ## example
@@ -60,7 +117,7 @@ module.exports = FormView.extend({
                 // you can also specify a boolean model attribute to render items as disabled
                 disabledAttribute: 'disabled',
                 // here you can specify if it should return the selected model from the
-                // collection, or just the id attribute
+                // collection, or just the id attribute.  defaults `true`
                 yieldModel: false
             })
         ];
@@ -68,14 +125,32 @@ module.exports = FormView.extend({
 });
 
 ```
+## gotchas
+
+* Numeric option values are generally stringified by the browser.  Be mindful doing comparisons.  You'll generally desire to inspect `selectView.value` (the value of your selected options' input) over `selectView.select.value` (the value returned from the browser).
+    * Additionally, do **not** use option sets containing values that `==` one another.  E.g., do not use options whose values are "2" (string) and 2 (number).  Browsers cannot distinguish between them in the select control context, thus nor can ampersand-select-view.
+* `null`, `undefined`, or `''` option values are not considered `valid` when the field is required.  This does not apply when options are from a collection and `yieldModel` is enabled.
+    * The `unselectedText` option will always be preferred in updating the control to an empty-ish value.
 
 ## browser support
 
 [![testling badge](https://ci.testling.com/AmpersandJS/ampersand-select-view.png)](https://ci.testling.com/AmpersandJS/ampersand-select-view)
 
+## changelog
+
+- 3.0.0
+1. Improve general option edge cases, and add supporting test cases.  Primarily targets falsy option value handling.
+1. Validate immediately to assist when parent FormView tests onload for field validity.  Update `skipValidation` to `skipValidationMessage`, permit immediate validation, but conditionally display messages.
+1. Throw an `Error` when trying to `setValue(value)` and an option *matching the requested `value`* does not exist.  The exception to this is when the provided value is `null`, `undefined`, or `''`, and a `null` option value exists.  Because the DOM can only recognize a single empty value for any <option>, which is the empty string `''`, only a single empty-ish option can only be supported by the view.
+1. Support `0` value options, both in Model id's and array values.
+1. Add `eagerValidate`.
+1. Denote a plan for 4.x release
+1. bulk update README, and some cody tidying
+
 ## credits
 
 Written by [@philip_roberts](twitter.com/philip_roberts).
+Lead Maintainer: [Christopher Dieringer (@cdaringe)](https://github.com/cdaringe)
 
 ## license
 

--- a/ampersand-select-view.js
+++ b/ampersand-select-view.js
@@ -2,6 +2,7 @@
 var domify = require('domify');
 var dom = require('ampersand-dom');
 var matches = require('matches-selector');
+var isArray = require('amp-is-array');
 
 //Replaceable with anything with label, message-container, message-text data-hooks and a <select>
 var defaultTemplate = [
@@ -15,25 +16,6 @@ var defaultTemplate = [
 ].join('\n');
 
 
-/* opts:
- *  - name:       name of the field
- *  - parent:     parent form reference
- *  - options:    array/collection of options to render into the select box
- *  - [unselectedText]: text to display if unselected
- *  - [value]:    initial value for the field
- *  - [el]:       dom node to use for the view
- *  - [required]: is field required
- *
- *  - [validClass]: class to apply to root element if valid
- *  - [invalidClass]: class to apply to root element if invalid
- *  - [requiredMessage]: message to display if invalid and required
- *
- *  Additional opts, if options is a collection:
- *  - [idAttribute]: model attribute to use as the id for the option node
- *  - [textAttribute]: model attribute to use as the text of the option node in the select box
- *  - [disabledAttribute]: boolean model attribute to flag disabling of the option node
- *  - [yieldModel]: (defaults true) if options is a collection, yields the full model rather than just it's id to .value
- */
 
 function SelectView (opts) {
     opts = opts || {};
@@ -53,36 +35,47 @@ function SelectView (opts) {
     }
 
     this.el = opts.el;
-    this.value = null;
-    this.label = opts.label || this.name;
+    this.label = opts.label || this.name; // init as string. render() mutates into DOM el with .textContent equal to this value
     this.parent = opts.parent;
     this.template = opts.template || defaultTemplate;
     this.unselectedText = opts.unselectedText;
     this.yieldModel = (opts.yieldModel === false) ? false : true;
 
     this.required = opts.required || false;
-    this.validClass = opts.validClass || 'input-valid';
-    this.invalidClass = opts.invalidClass || 'input-invalid';
+    this.validClass = opts.validClass || 'select-valid';
+    this.invalidClass = opts.invalidClass || 'select-invalid';
     this.requiredMessage = opts.requiredMessage || 'Selection required';
 
     this.onChange = this.onChange.bind(this);
 
     this.render();
 
-    this.setValue(opts.value);
+    this.setValue(opts.value, opts.eagerValidate ? false : true);
 }
 
 SelectView.prototype.render = function () {
+    var elDom,
+        labelEl;
     if (this.rendered) return;
 
-    if (!this.el) this.el = domify(this.template);
+    elDom = domify(this.template);
+    if (!this.el) this.el = elDom;
+    else this.el.appendChild(elDom);
 
-    var label = this.el.querySelector('[data-hook~=label]');
-    if (label) {
-        label.textContent = this.label;
+    labelEl = this.el.querySelector('[data-hook~=label]');
+    if (labelEl) {
+        labelEl.textContent = this.label;
+        this.label = labelEl;
+    } else {
+        delete this.label;
     }
 
-    this.select = this.el.querySelector('select');
+    if (this.el.tagName === 'SELECT') {
+        this.select = this.el;
+    } else {
+        this.select = this.el.querySelector('select');
+    }
+    if (!this.select) throw new Error('no select found in template');
     if (matches(this.el, 'select')) this.select = this.el;
     if (this.select) this.select.setAttribute('name', this.name);
 
@@ -100,21 +93,26 @@ SelectView.prototype.render = function () {
     this.rendered = true;
 };
 
+
 SelectView.prototype.onChange = function () {
     var value = this.select.options[this.select.selectedIndex].value;
 
     if (this.options.isCollection && this.yieldModel) {
-        value = this.findModelForId(value);
+        value = this.getModelForId(value);
     }
 
     this.setValue(value);
 };
 
-SelectView.prototype.findModelForId = function (id) {
+/**
+ * Finds a model in the options collection provided an ID
+ * @param  {any} id
+ * @return {State}
+ * @throws {RangeError} If model not found
+ */
+SelectView.prototype.getModelForId = function (id) {
     return this.options.filter(function (model) {
-        if (!model[this.idAttribute]) return false;
-
-        //intentionally coerce for '1' == 1
+        // intentionally coerce for '1' == 1
         return model[this.idAttribute] == id;
     }.bind(this))[0];
 };
@@ -135,37 +133,45 @@ SelectView.prototype.renderOptions = function () {
 
     this.options.forEach(function (option) {
         this.select.appendChild(
-            createOption(this.getOptionValue(option), this.getOptionText(option), this.getOptionDisabled(option))
+            createOption(
+                this.getOptionValue(option),
+                this.getOptionText(option),
+                this.getOptionDisabled(option)
+            )
         );
     }.bind(this));
 };
 
+/**
+ * Updates the <select> control to set the select option when the option
+ * has changed programatically (i.e. not through direct user selection)
+ * @return {SelectView} this
+ * @throws {Error} If no option exists for this.value
+ */
 SelectView.prototype.updateSelectedOption = function () {
     var lookupValue = this.value;
 
-    if (!this.select) return;
-
-    if (!lookupValue) {
+    if (lookupValue === null || lookupValue === undefined || lookupValue === '') {
         this.select.selectedIndex = 0;
-        return;
+        return this;
     }
 
-    //Pull out the id if it's a model
+    // Pull out the id if it's a model
     if (this.options.isCollection && this.yieldModel) {
         lookupValue = lookupValue && lookupValue[this.idAttribute];
     }
 
-    if (lookupValue) {
+    if (lookupValue || lookupValue === 0) {
         for (var i = this.select.options.length; i--; i) {
-            if (this.select.options[i].value === lookupValue.toString()) {
+            if (this.select.options[i].value == lookupValue) {
                 this.select.selectedIndex = i;
-                return;
+                return this;
             }
         }
     }
 
-    //If failed to match any
-    this.select.selectedIndex = 0;
+    // failed to match any
+    throw new Error('no option exists for value: ' + lookupValue);
 };
 
 SelectView.prototype.remove = function () {
@@ -173,82 +179,83 @@ SelectView.prototype.remove = function () {
     this.el.removeEventListener('change', this.onChange, false);
 };
 
+/**
+ * Sets control to unselectedText option, or user specified option with `null`
+ * value
+ * @return {SelectView} this
+ */
 SelectView.prototype.clear = function() {
-    this.setValue('', true);
+    this.setValue(null, true);
+    return this;
 };
 
-SelectView.prototype.setValue = function (value, skipValidation) {
-    if (value === this.value) return;
-
-    //Coerce and find the right value based on yieldModel
-    if (this.options.isCollection) {
-        var model;
-
-        if (this.options.indexOf(value) === -1) {
-            model = this.findModelForId(value);
-        } else {
-            model = value;
-        }
-
-        if (this.yieldModel) {
-            value = model;
-        } else {
-            if (model) {
-                value = model[this.idAttribute];
-            } else {
-                value = void 0;
-            }
-        }
+SelectView.prototype.setValue = function (value, skipValidationMessage) {
+    var option;
+    if (value === null || value === undefined || value === '') {
+        this.value = null;
+    } else {
+        // Ensure corresponding option exists before assigning value
+        option = this.getOptionByValue(value);
+        this.value = isArray(option) ? option[0] : option;
     }
-
-    this.value = value;
-    if(!skipValidation) this.validate();
+    this.validate(skipValidationMessage);
     this.updateSelectedOption();
     if (this.parent) this.parent.update(this);
+    return this;
 };
 
-SelectView.prototype.validate = function () {
-    if(!this.value && !this.required) {
+SelectView.prototype.validate = function (skipValidationMessage) {
+    if (!this.required) {
+        // selected option always known to be in option set,
+        // thus field is always valid if not required
         this.valid = true;
-    } else {
-        this.valid = this.options.some(function (element) {
-            //If it's a collection, ensure it's in the collection
-            if (this.options.isCollection) {
-                if (this.yieldModel) {
-                    return this.options.indexOf(this.value) > -1;
-                } else {
-                    return !!this.findModelForId(this.value);
-                }
-            }
-
-            //[ ['foo', 'Foo Text'], ['bar', 'Bar Text'] ]
-            if (Array.isArray(element) && element.length === 2) {
-                return element[0] === this.value;
-            }
-
-            //[ 'foo', 'bar', 'baz' ]
-            return element === this.value;
-        }.bind(this));
+        return this.valid;
     }
 
-    if (!this.valid && this.required) {
-        this.setMessage(this.requiredMessage);
+    if (this.required && !this.value && this.value !== 0) {
+        this.valid = false;
+        if (!skipValidationMessage) this.setMessage(this.requiredMessage);
     } else {
-        this.setMessage();
+        this.valid = true;
+        if (!skipValidationMessage) this.setMessage();
     }
 
     return this.valid;
 };
 
+
+
+/**
+ * Gets the option corresponding to provided value.
+ * @param  {*} string, state, or model
+ * @return {*} string, array, state, or model
+ */
+SelectView.prototype.getOptionByValue = function(value) {
+    var model;
+    if (this.options.isCollection) {
+        // find value in collection, error if no model found
+        if (this.options.indexOf(value) === -1) model = this.getModelForId(value);
+        else model = value;
+        return this.yieldModel ? model : model[this.idAttribute];
+    } else if (isArray(this.options)) {
+        // find value value in options array
+        // find option, formatted [['val', 'text'], ...]
+        if (this.options.length && isArray(this.options[0])) {
+            for (var i = this.options.length - 1; i >= 0; i--) {
+                if (this.options[i][0] == value) return this.options[i];
+            }
+        }
+        // find option, formatted ['valAndText', ...] format
+        if (this.options.length && this.options.indexOf(value) !== -1) return value;
+        throw new Error('value not in set of provided options');
+    }
+    throw new Error('select option set invalid');
+};
+
+
 SelectView.prototype.getOptionValue = function (option) {
     if (Array.isArray(option)) return option[0];
-
-    if (this.options.isCollection) {
-        if (this.idAttribute && option[this.idAttribute]) {
-            return option[this.idAttribute];
-        }
-    }
-
+    if (this.options.isCollection) return option[this.idAttribute];
     return option;
 };
 

--- a/ampersand-select-view.js
+++ b/ampersand-select-view.js
@@ -42,8 +42,8 @@ function SelectView (opts) {
     this.yieldModel = (opts.yieldModel === false) ? false : true;
 
     this.required = opts.required || false;
-    this.validClass = opts.validClass || 'select-valid';
-    this.invalidClass = opts.invalidClass || 'select-invalid';
+    this.validClass = opts.validClass || 'input-valid';
+    this.invalidClass = opts.invalidClass || 'input-invalid';
     this.requiredMessage = opts.requiredMessage || 'Selection required';
 
     this.onChange = this.onChange.bind(this);

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -21,6 +21,27 @@ var collection1 = new Collection([
 
 var BaseView = FormView.extend({
     fields: function () {
+        var requiredInvalid = window.requiredInvalid = new SelectView({
+                name: 'three.2',
+                parent: this,
+                options: collection1,
+                idAttribute: 'id',
+                textAttribute: 'title',
+                required: true,
+                unselectedText: 'show validation stuff when im selected after initial'
+        });
+
+        var requiredInvalidEager = window.requiredInvalidEager = new SelectView({
+                name: 'three.2',
+                parent: this,
+                options: collection1,
+                idAttribute: 'id',
+                textAttribute: 'title',
+                required: true,
+                eagerValidate: true,
+                unselectedText: 'show validation stuff when im selected no matter what'
+        });
+
         return [
             new SelectView({
                 name: 'one.1',
@@ -65,9 +86,11 @@ var BaseView = FormView.extend({
                 textAttribute: 'title',
                 unselectedText: 'please choose one'
             }),
+            requiredInvalid,
+            requiredInvalidEager,
 
             new SelectView({
-                name: 'three.1',
+                name: 'three.3',
                 parent: this,
                 options: collection1,
                 value: collection1.at(2),

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,3 +1,6 @@
+<!--
+To see the demo, exec `npm run demo` and open the posted URL
+-->
 <script src='demo.js'></script>
 
 <style>

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "ampersand-select-view",
   "description": "A view module for intelligently rendering and validating selectbox input. Works well with ampersand-form-view.",
-  "version": "2.4.2",
+  "version": "3.0.0",
   "author": "Philip Roberts <phil@andyet.net>",
   "bugs": {
     "url": "https://github.com/AmpersandJS/ampersand-select-view/issues"
   },
   "dependencies": {
+    "amp-is-array": "^1.0.1",
     "ampersand-dom": "^1.1.0",
     "ampersand-version": "^1.0.1",
     "domify": "^1.2.2",

--- a/test/index.js
+++ b/test/index.js
@@ -3,6 +3,7 @@ var viewConventions = require('ampersand-view-conventions');
 var SelectView = require('../ampersand-select-view');
 var AmpersandState = require('ampersand-state');
 var AmpersandCollection = require('ampersand-collection');
+var dom = require('ampersand-dom');
 
 var Model = AmpersandState.extend({
     props: {
@@ -13,8 +14,20 @@ var Model = AmpersandState.extend({
     }
 });
 
+var VolatileModel = AmpersandState.extend({
+    props: {
+        id: 'any', // lookout!,
+        title: 'string',
+        disabled: 'boolean'
+    }
+});
+
 var Collection = AmpersandCollection.extend({
     model: Model
+});
+
+var VolatileCollection = AmpersandCollection.extend({
+    model: VolatileModel
 });
 
 if (!Function.prototype.bind) Function.prototype.bind = require('function-bind');
@@ -23,6 +36,9 @@ var fieldOptions = {
     name: 'word',
     options: ['foo', 'bar', 'baz']
 };
+var view;
+var arr, arrNum;
+var coll;
 
 viewConventions.view(suite.tape, SelectView, fieldOptions);
 viewConventions.formField(suite.tape, SelectView, fieldOptions, 'foo');
@@ -35,16 +51,14 @@ var sync = function (cb) {
     };
 };
 
-suite('Setup', function (s) {
-    var view;
 
+suite('Setup', function (s) {
     s.beforeEach(function () {
-        var fieldOptions = {
+        fieldOptions = {
             name: 'word',
             label: 'Choose a word',
             options: ['foo', 'bar', 'baz']
         };
-
         view = new SelectView(fieldOptions);
     });
 
@@ -77,13 +91,53 @@ suite('Setup', function (s) {
         var selectName = view.el.querySelector('select').getAttribute('name');
         t.equal(selectName, 'word');
     }));
+
+    s.test('eagerValidation', sync(function (t) {
+        view = new SelectView({
+            name: 'num',
+            options: fieldOptions.options,
+            eagerValidate: true,
+            required: true,
+            unselectedText: 'default'
+        });
+
+        t.ok(dom.hasClass(view.el, view.invalidClass), 'validation message should be present on el with eagerValidate');
+    }));
+
+});
+
+suite('Options array with number items', function (s) {
+    s.beforeEach(function () {
+        arr = [0, 1, 1.5, 2];
+        view = null;
+    });
+
+    s.test('renders the number options into the select', sync(function (t) {
+        view = new SelectView({ name: 'num', options: arr });
+
+        var optionNodes = view.el.querySelectorAll('select option');
+
+        t.equal(optionNodes.length, 4);
+
+        t.equal(optionNodes[0].value, '0');
+        t.equal(optionNodes[0].textContent, '0');
+
+        t.equal(optionNodes[1].value, '1');
+        t.equal(optionNodes[1].textContent, '1');
+
+        t.equal(optionNodes[2].value, '1.5');
+        t.equal(optionNodes[2].textContent, '1.5');
+    }));
+
 });
 
 suite('Options array with string items', function (s) {
-    var arr = ['one', 'two', 'three'];
-    var view;
+    s.beforeEach(function () {
+        arr = ['one', 'two', 'three'];
+        view = null;
+    });
 
-    s.test('renders the options into the select', sync(function (t) {
+    s.test('renders the options into the select (array)', sync(function (t) {
         view = new SelectView({ name: 'word', options: arr });
 
         var optionNodes = view.el.querySelectorAll('select option');
@@ -118,7 +172,7 @@ suite('Options array with string items', function (s) {
         t.equal(optionNodes[1].textContent, 'one');
     }));
 
-    s.test('selects the right item', sync(function (t) {
+    s.test('selects the right item (options: [\'valAndText\'])', sync(function (t) {
         view = new SelectView({ name: 'word', options: arr, unselectedText: 'Please choose:', value: 'two' });
 
         var select = view.el.querySelector('select');
@@ -131,25 +185,50 @@ suite('Options array with string items', function (s) {
         view.setValue('one');
         t.equal(select.options[select.selectedIndex].value, 'one');
 
-        view.setValue('totes-wrong');
-        t.equal(select.options[select.selectedIndex].innerHTML, 'Please choose:');
-
+        try {
+            view.setValue('invalid-option');
+            t.ok(false, 'unable to set invalid option');
+        } catch (err) {
+            t.ok(true, 'unable to set invalid option');
+        }
     }));
 
     s.test('options are enabled', sync(function (t) {
+        view = new SelectView({ name: 'word', options: arr, unselectedText: 'Please choose:', value: 'two' });
         var optionNodes = view.el.querySelectorAll('select option');
-
         t.equal(optionNodes[0].disabled, false);
         t.equal(optionNodes[1].disabled, false);
         t.equal(optionNodes[2].disabled, false);
     }));
+
 });
 
 suite('Options array with array items', function (s) {
-    var arr =  [ ['one', 'Option One'], ['two', 'Option Two', false], ['three', 'Option Three', true] ];
-    var view;
+    s.beforeEach(function() {
+        arr =  [ ['one', 'Option One'], ['two', 'Option Two', false], ['three', 'Option Three', true] ];
+        arrNum =  [ [0, 'Option Zero'], [1, 1, false], [1.5, 1.5, true] ];
+        view = null;
+    });
 
-    s.test('renders the options into the select', sync(function (t) {
+    s.test('renders the arr-num options into the select', sync(function (t) {
+        view = new SelectView({ name: 'num', options: arrNum });
+
+        var optionNodes = view.el.querySelectorAll('select option');
+
+        t.equal(optionNodes.length, 3);
+
+        t.equal(optionNodes[0].value, '0');
+        t.equal(optionNodes[0].textContent, 'Option Zero');
+
+        t.equal(optionNodes[1].value, '1');
+        t.equal(optionNodes[1].textContent, '1');
+
+        t.equal(optionNodes[2].value, '1.5');
+        t.equal(optionNodes[2].textContent, '1.5');
+        t.ok(optionNodes[2].disabled, true);
+    }));
+
+    s.test('renders the arr-str options into the select', sync(function (t) {
         view = new SelectView({ name: 'word', options: arr });
 
         var optionNodes = view.el.querySelectorAll('select option');
@@ -184,7 +263,7 @@ suite('Options array with array items', function (s) {
         t.equal(optionNodes[1].textContent, 'Option One');
     }));
 
-    s.test('selects the right item', sync(function (t) {
+    s.test('selects the right item (options:  [[\'val\', \'text\']])', sync(function (t) {
         view = new SelectView({ name: 'word', options: arr, unselectedText: 'Please choose:', value: 'two' });
 
         var select = view.el.querySelector('select');
@@ -197,8 +276,12 @@ suite('Options array with array items', function (s) {
         view.setValue('one');
         t.equal(select.options[select.selectedIndex].value, 'one');
 
-        view.setValue('totes-wrong');
-        t.equal(select.options[select.selectedIndex].innerHTML, 'Please choose:');
+        try {
+            view.setValue('totes-wrong');
+            t.ok(false, 'unable to set invalid option');
+        } catch(err) {
+            t.ok('unable to set invalid option');
+        }
     }));
 
     s.test('renders a disabled item if a third value is passed which is truthy', sync(function (t) {
@@ -213,14 +296,17 @@ suite('Options array with array items', function (s) {
 });
 
 suite('With ampersand collection', function (s) {
-    var coll = new Collection([
-        { id: 1, someOtherKey: 'foo', title: 'Option one' },
-        { id: 2, someOtherKey: 'bar', title: 'Option two' },
-        { id: 3, someOtherKey: 'baz', title: 'Option three' }
-    ]);
-    var view;
+    s.beforeEach(function() {
+        view = null;
+        coll = new Collection([
+            { id: 0, someOtherKey: 'zero', title: 'Option zero' },
+            { id: 1, someOtherKey: 'foo',  title: 'Option one' },
+            { id: 2, someOtherKey: 'bar',  title: 'Option two' },
+            { id: 3, someOtherKey: 'baz',  title: 'Option three' }
+        ]);
+    });
 
-    s.test('renders the options into the select', sync(function (t) {
+    s.test('renders the options into the select (collection)', sync(function (t) {
         view = new SelectView({
             name: 'word',
             options: coll,
@@ -229,17 +315,19 @@ suite('With ampersand collection', function (s) {
         });
 
         var optionNodes = view.el.querySelectorAll('select option');
+        t.equal(optionNodes.length, 4, 'node list length (collection)');
 
-        t.equal(optionNodes.length, 3);
+        t.equal(optionNodes[0].value, '0');
+        t.equal(optionNodes[0].textContent, 'Option zero');
 
-        t.equal(optionNodes[0].value, '1');
-        t.equal(optionNodes[0].textContent, 'Option one');
+        t.equal(optionNodes[1].value, '1');
+        t.equal(optionNodes[1].textContent, 'Option one');
 
-        t.equal(optionNodes[1].value, '2');
-        t.equal(optionNodes[1].textContent, 'Option two');
+        t.equal(optionNodes[2].value, '2');
+        t.equal(optionNodes[2].textContent, 'Option two');
 
-        t.equal(optionNodes[2].value, '3');
-        t.equal(optionNodes[2].textContent, 'Option three');
+        t.equal(optionNodes[3].value, '3');
+        t.equal(optionNodes[3].textContent, 'Option three');
     }));
 
     s.test('rerenders if the collection changes', sync(function (t) {
@@ -286,7 +374,7 @@ suite('With ampersand collection', function (s) {
         t.equal(optionNodes[1].textContent, 'Option twenty');
     }));
 
-    s.test('renders the options into the select with different id attribute', sync(function (t) {
+    s.test('renders the options into the select with different id attribute (collection)', sync(function (t) {
         view = new SelectView({
             name: 'word',
             options: coll,
@@ -296,11 +384,12 @@ suite('With ampersand collection', function (s) {
 
         var optionNodes = view.el.querySelectorAll('select option');
 
-        t.equal(optionNodes.length, 3);
+        t.equal(optionNodes.length, 4);
 
-        t.equal(optionNodes[0].value, 'foo');
-        t.equal(optionNodes[1].value, 'bar');
-        t.equal(optionNodes[2].value, 'baz');
+        t.equal(optionNodes[0].value, 'zero');
+        t.equal(optionNodes[1].value, 'foo');
+        t.equal(optionNodes[2].value, 'bar');
+        t.equal(optionNodes[3].value, 'baz');
     }));
 
     s.test('renders the empty item', sync(function (t) {
@@ -314,16 +403,43 @@ suite('With ampersand collection', function (s) {
 
         var optionNodes = view.el.querySelectorAll('select option');
 
-        t.equal(optionNodes.length, 4);
+        t.equal(optionNodes.length, 5);
 
         t.equal(optionNodes[0].value, '');
         t.equal(optionNodes[0].innerHTML, 'Please choose:');
 
-        t.equal(optionNodes[1].value, '1');
-        t.equal(optionNodes[1].textContent, 'Option one');
+        t.equal(optionNodes[2].value, '1');
+        t.equal(optionNodes[2].textContent, 'Option one');
     }));
 
-    s.test('selects the right item by id/model', sync(function (t) {
+    s.test('exhibits normal behavior on null model option', sync(function (t) {
+        var coll = new VolatileCollection([
+            { id: 0, someOtherKey: 'foo', title: 'Option zero' },
+            { id: null, someOtherKey: 'bar', title: 'Option null' },
+            { id: 2, someOtherKey: 'baz', title: 'Option two' },
+        ]);
+        view = new SelectView({
+            name: 'testNullId',
+            options: coll,
+            idAttribute: 'id',
+            textAttribute: 'title'
+        });
+
+        var optionNodes = view.el.querySelectorAll('select option');
+
+        t.equal(optionNodes.length, 3);
+
+        t.equal(optionNodes[0].value, '0', 'option before null model has correct value');
+        t.equal(optionNodes[0].textContent, 'Option zero');
+
+        t.equal(view.value, null); // null option set by default when no value provided
+        t.equal(optionNodes[1].value, '');
+
+        t.equal(optionNodes[2].value, '2', 'option after null model has correct value');
+        t.equal(optionNodes[2].textContent, 'Option two');
+    }));
+
+    s.test('selects the right item by id/model (options: collection)', sync(function (t) {
         view = new SelectView({
             name: 'word',
             options: coll,
@@ -336,32 +452,27 @@ suite('With ampersand collection', function (s) {
 
         var select = view.el.querySelector('select');
 
-        t.equal(view.value, coll.at(1));
+        t.equal(view.value, coll.at(2));
         t.ok(view.valid);
         t.equal(select.options[select.selectedIndex].innerHTML, 'Option two');
 
-        view.setValue(undefined);
-        t.equal(view.value, undefined);
+        view.clear();
+        t.equal(view.value, null);
         t.notOk(view.valid);
         t.equal(select.options[select.selectedIndex].innerHTML, 'Please choose:');
 
         view.setValue('1');
-        t.equal(view.value, coll.at(0));
+        t.equal(view.value, coll.at(1));
         t.ok(view.valid);
         t.equal(select.options[select.selectedIndex].innerHTML, 'Option one');
 
-        view.setValue('totes-wrong');
-        t.equal(view.value, undefined);
-        t.notOk(view.valid);
-        t.equal(select.options[select.selectedIndex].innerHTML, 'Please choose:');
-
-        view.setValue(coll.at(1));
-        t.equal(view.value, coll.at(1));
+        view.setValue(coll.at(2));
+        t.equal(view.value, coll.at(2));
         t.ok(view.valid);
         t.equal(select.options[select.selectedIndex].innerHTML, 'Option two');
     }));
 
-    s.test('selects the right item by id/model, with yieldModel: false', sync(function (t) {
+    s.test('selects the right item by id/model (options: collection), with yieldModel: false', sync(function (t) {
         view = new SelectView({
             name: 'word',
             options: coll,
@@ -380,7 +491,7 @@ suite('With ampersand collection', function (s) {
         t.equal(select.options[select.selectedIndex].innerHTML, 'Option two');
 
         view.setValue(undefined);
-        t.equal(view.value, void 0);
+        t.equal(view.value, null);
         t.notOk(view.valid);
         t.equal(select.options[select.selectedIndex].innerHTML, 'Please choose:');
 
@@ -389,15 +500,17 @@ suite('With ampersand collection', function (s) {
         t.ok(view.valid);
         t.equal(select.options[select.selectedIndex].innerHTML, 'Option one');
 
-        view.setValue('totes-wrong');
-        t.equal(view.value, void 0);
-        t.notOk(view.valid);
-        t.equal(select.options[select.selectedIndex].innerHTML, 'Please choose:');
-
-        view.setValue(coll.at(1));
+        view.setValue(coll.get(2));
         t.equal(view.value, 2);
         t.ok(view.valid);
         t.equal(select.options[select.selectedIndex].innerHTML, 'Option two');
+
+        try {
+            view.setValue(1000);
+            t.ok(false, 'should not be able to set invalid model id or model obj');
+        } catch (err) {
+            t.ok(true, 'should not be able to set invalid model id or model obj');
+        }
     }));
 
     s.test('renders a disabled item for a model that has the attribute specified in the disabledAttribute option set to truthy', sync(function (t) {
@@ -424,4 +537,5 @@ suite('With ampersand collection', function (s) {
         t.equal(optionNodes[3].disabled, false);
         t.equal(optionNodes[4].disabled, true);
     }));
+
 });

--- a/testem.json
+++ b/testem.json
@@ -1,7 +1,6 @@
 {
     "framework": "tap",
     "src_files": [
-        "ampersand-select-view.js",
         "test/*.js"
     ],
     "serve_files": [


### PR DESCRIPTION
**tldr: this PR is large.  we can setup core-crew talky to go over this change if desired.**

This PR fixes https://github.com/AmpersandJS/ampersand-select-view/issues/5.  It addresses a variety of other opens as well.

Per the new README.md changelog:

## changelog

1. Improve general option edge cases, and add supporting test cases.  Primarily targets falsy option value handling.
1. Validate immediately to assist when parent FormView tests onload for field validity.  Update `skipValidation` to `skipValidationMessage`, permit immediate validation, but conditionally display messages.
1. Throw an `Error` when trying to `setValue(value)` and an option *matching the requested `value`* does not exist.  The exception to this is when the provided value is `null`, `undefined`, or `''`, and a `null` option value exists.  Because the DOM can only recognize a single empty value for any `<option>`, which is the empty string `''`, only a single empty-ish option can only be supported by the view.
1. Support `0` value options, both in Model id's and array values.
1. Add `eagerValidate`.
1. Denote a plan for 4.x release
1. bulk update README, and some cody tidying