### PR TITLE
reset and beforeSubmit Methods. Explicitly hide message container on setup. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,5 @@ addons:
   sauce_connect:
     username: ampersandjs-ci
     access_key:
-      secure: "qZGwdyj62108JOiUMZjgLGCQ8k9G/Z3HDhqzxaMmFC0PgxYX6Z0IglTeYdTUWhalIzjM/WplW2iV3i0hfM8ufvLh1XVHZfFb0ZUtAi7i8fmJMHUflQ3/8E3rJGsLRn06Z+mW1nJB2aC2BgqCKlu4qhYKfTAH1/wr4sd8ZMG87vg="
+      secure: "gd/90cxn7Z9li+nKDKTxuKizhCdL2LdRd1fiPuK8oEgRRNXAYnQzmY9Gw9DUjDPPsW5VtBWKdRcADJhzQcumTwGu34+m0GL7JK8H5Wcmu4JBlSP68kTXNOvONVe4jCwLZmllMV6fxiVDRxHAgCKniaOL1L+crn+zx5eBSDrTITQ="
+

--- a/ampersand-select-view.js
+++ b/ampersand-select-view.js
@@ -237,7 +237,7 @@ SelectView.prototype.validate = function (skipValidationMessage) {
 };
 
 /**
- * Called by ForumView on submit 
+ * Called by FormView on submit 
  * @return {SelectView} this
  */
 SelectView.prototype.beforeSubmit = function () {

--- a/ampersand-select-view.js
+++ b/ampersand-select-view.js
@@ -39,6 +39,7 @@ function SelectView (opts) {
     this.parent = opts.parent;
     this.template = opts.template || defaultTemplate;
     this.unselectedText = opts.unselectedText;
+    this.startingValue = opts.value;
     this.yieldModel = (opts.yieldModel === false) ? false : true;
 
     this.required = opts.required || false;
@@ -189,6 +190,23 @@ SelectView.prototype.clear = function() {
     return this;
 };
 
+/**
+ * Sets control to option with the same value as initial value if specified, falls 
+ * back to unselectedText or first avaialable option depending on availability
+ * @return {SelectView} this
+ */
+SelectView.prototype.reset = function() {
+    if(this.startingValue) {
+        this.setValue(this.startingValue, true);
+    } else if(this.unselectedText) {
+        this.setValue(null, true);
+    } else if(this.select.options[0] && this.select.options[0].value) {
+        this.setValue(this.select.options[0].value, true);
+    }
+
+    return this;
+};
+
 SelectView.prototype.setValue = function (value, skipValidationMessage) {
     var option;
     if (value === null || value === undefined || value === '') {
@@ -223,7 +241,14 @@ SelectView.prototype.validate = function (skipValidationMessage) {
     return this.valid;
 };
 
-
+/**
+ * Called by ForumView on submit 
+ * @return {SelectView} this
+ */
+SelectView.prototype.beforeSubmit = function () {
+    this.setValue(this.select.options[this.select.selectedIndex] && this.select.options[this.select.selectedIndex].value, false);
+    return this;
+};
 
 /**
  * Gets the option corresponding to provided value.

--- a/ampersand-select-view.js
+++ b/ampersand-select-view.js
@@ -198,10 +198,7 @@ SelectView.prototype.clear = function() {
  * @return {SelectView} this
  */
 SelectView.prototype.reset = function() {
-    if(this.startingValue !== undefined) {
-        this.setValue(this.startingValue, true);
-    }
-
+    if(this.startingValue !== undefined) this.setValue(this.startingValue, true);
     return this;
 };
 
@@ -245,7 +242,6 @@ SelectView.prototype.validate = function (skipValidationMessage) {
  */
 SelectView.prototype.beforeSubmit = function () {
     this.setValue(this.select.options[this.select.selectedIndex].value);
-    
     return this;
 };
 

--- a/ampersand-select-view.js
+++ b/ampersand-select-view.js
@@ -261,6 +261,7 @@ SelectView.prototype.validate = function (skipValidationMessage) {
         // selected option always known to be in option set,
         // thus field is always valid if not required
         this.valid = true;
+        if (this.select) this.toggleMessage(skipValidationMessage);
         return this.valid;
     }
 

--- a/ampersand-select-view.js
+++ b/ampersand-select-view.js
@@ -198,7 +198,7 @@ SelectView.prototype.clear = function() {
 
 /**
  * Sets control to option with the same value as initial value if specified, falls 
- * back to unselectedText or first avaialable option depending on availability
+ * back to either unselectedText or first option depending on availability
  * @return {SelectView} this
  */
 SelectView.prototype.reset = function() {

--- a/ampersand-select-view.js
+++ b/ampersand-select-view.js
@@ -91,10 +91,6 @@ SelectView.prototype.render = function () {
         }.bind(this));
     }
 
-    // Message DOM nodes
-    this.mContainer = this.el.querySelector('[data-hook~=message-container]');
-    this.mText = this.el.querySelector('[data-hook~=message-text]');
-
     this.rendered = true;
 
     return this;
@@ -197,15 +193,13 @@ SelectView.prototype.clear = function() {
 };
 
 /**
- * Sets control to option with the same value as initial value if specified, falls 
- * back to either unselectedText or first option depending on availability
+ * Sets the selected option and view value to the original option value provided 
+ * during construction
  * @return {SelectView} this
  */
 SelectView.prototype.reset = function() {
-    if(this.startingValue) {
+    if(this.startingValue !== undefined) {
         this.setValue(this.startingValue, true);
-    } else {
-        this.setValue(this.select.options[0] && this.select.options[0].value, true);
     }
 
     return this;
@@ -250,7 +244,8 @@ SelectView.prototype.validate = function (skipValidationMessage) {
  * @return {SelectView} this
  */
 SelectView.prototype.beforeSubmit = function () {
-    this.setValue(this.select.options[this.select.selectedIndex] && this.select.options[this.select.selectedIndex].value);
+    this.setValue(this.select.options[this.select.selectedIndex].value);
+    
     return this;
 };
 
@@ -309,24 +304,27 @@ SelectView.prototype.getOptionDisabled = function (option) {
 };
 
 SelectView.prototype.toggleMessage = function (hide, message) {
-    if (!this.mContainer || !this.mText) return;
+    var mContainer = this.el.querySelector('[data-hook~=message-container]'),
+        mText = this.el.querySelector('[data-hook~=message-text]');
+
+    if (!mContainer || !mText) return;
 
     if(hide) {
-        dom.hide(this.mContainer);
-        this.mText.textContent = '';
+        dom.hide(mContainer);
+        mText.textContent = '';
         dom.removeClass(this.el, this.validClass);
         dom.removeClass(this.el, this.invalidClass);
         return;
     }
 
     if (message) {
-        dom.show(this.mContainer);
-        this.mText.textContent = message;
+        dom.show(mContainer);
+        mText.textContent = message;
         dom.addClass(this.el, this.invalidClass);
         dom.removeClass(this.el, this.validClass);
     } else {
-        dom.hide(this.mContainer);
-        this.mText.textContent = '';
+        dom.hide(mContainer);
+        mText.textContent = '';
         dom.addClass(this.el, this.validClass);
         dom.removeClass(this.el, this.invalidClass);
     }

--- a/ampersand-select-view.js
+++ b/ampersand-select-view.js
@@ -91,7 +91,13 @@ SelectView.prototype.render = function () {
         }.bind(this));
     }
 
+    // Message DOM nodes
+    this.mContainer = this.el.querySelector('[data-hook~=message-container]');
+    this.mText = this.el.querySelector('[data-hook~=message-text]');
+
     this.rendered = true;
+
+    return this;
 };
 
 
@@ -230,10 +236,10 @@ SelectView.prototype.validate = function (skipValidationMessage) {
 
     if (this.required && !this.value && this.value !== 0) {
         this.valid = false;
-        if (!skipValidationMessage) this.setMessage(this.requiredMessage);
+        this.toggleMessage(skipValidationMessage, this.requiredMessage);
     } else {
         this.valid = true;
-        if (!skipValidationMessage) this.setMessage();
+        this.toggleMessage(skipValidationMessage);
     }
 
     return this.valid;
@@ -244,7 +250,7 @@ SelectView.prototype.validate = function (skipValidationMessage) {
  * @return {SelectView} this
  */
 SelectView.prototype.beforeSubmit = function () {
-    this.setValue(this.select.options[this.select.selectedIndex] && this.select.options[this.select.selectedIndex].value, false);
+    this.setValue(this.select.options[this.select.selectedIndex] && this.select.options[this.select.selectedIndex].value);
     return this;
 };
 
@@ -302,20 +308,25 @@ SelectView.prototype.getOptionDisabled = function (option) {
     return false;
 };
 
-SelectView.prototype.setMessage = function (message) {
-    var mContainer = this.el.querySelector('[data-hook~=message-container]');
-    var mText = this.el.querySelector('[data-hook~=message-text]');
+SelectView.prototype.toggleMessage = function (hide, message) {
+    if (!this.mContainer || !this.mText) return;
 
-    if (!mContainer || !mText) return;
+    if(hide) {
+        dom.hide(this.mContainer);
+        this.mText.textContent = '';
+        dom.removeClass(this.el, this.validClass);
+        dom.removeClass(this.el, this.invalidClass);
+        return;
+    }
 
     if (message) {
-        dom.show(mContainer);
-        mText.textContent = message;
+        dom.show(this.mContainer);
+        this.mText.textContent = message;
         dom.addClass(this.el, this.invalidClass);
         dom.removeClass(this.el, this.validClass);
     } else {
-        dom.hide(mContainer);
-        mText.textContent = '';
+        dom.hide(this.mContainer);
+        this.mText.textContent = '';
         dom.addClass(this.el, this.validClass);
         dom.removeClass(this.el, this.invalidClass);
     }

--- a/ampersand-select-view.js
+++ b/ampersand-select-view.js
@@ -198,10 +198,8 @@ SelectView.prototype.clear = function() {
 SelectView.prototype.reset = function() {
     if(this.startingValue) {
         this.setValue(this.startingValue, true);
-    } else if(this.unselectedText) {
-        this.setValue(null, true);
-    } else if(this.select.options[0] && this.select.options[0].value) {
-        this.setValue(this.select.options[0].value, true);
+    } else {
+        this.setValue(this.select.options[0] && this.select.options[0].value, true);
     }
 
     return this;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ampersand-select-view",
   "description": "A view module for intelligently rendering and validating selectbox input. Works well with ampersand-form-view.",
-  "version": "2.4.2",
+  "version": "3.0.0",
   "author": "Philip Roberts <phil@andyet.net>",
   "bugs": {
     "url": "https://github.com/AmpersandJS/ampersand-select-view/issues"

--- a/test/index.js
+++ b/test/index.js
@@ -226,6 +226,7 @@ suite('Utility Methods', function (s) {
 
         view.reset();
         t.equal(select.options[select.selectedIndex].value, '');
+        t.equal(select.options[select.selectedIndex].text, 'Please choose:');
     }));
 
     s.test('beforeSubmit', sync(function (t) {

--- a/test/index.js
+++ b/test/index.js
@@ -101,7 +101,7 @@ suite('Setup', function (s) {
             unselectedText: 'default'
         });
 
-        t.ok(view.mContainer.style.display === 'none', 'validation message should be hidden if eagerValidate is false');
+        t.ok(view.el.querySelector('[data-hook~=message-container]').style.display === 'none', 'validation message should be hidden if eagerValidate is false');
 
         view = new SelectView({
             name: 'num',
@@ -111,7 +111,7 @@ suite('Setup', function (s) {
             unselectedText: 'default'
         });
 
-        t.ok(view.mContainer.style.display !== 'none', 'validation message should be displayed if eagerValidate is true');
+        t.ok(view.el.querySelector('[data-hook~=message-container]').style.display !== 'none', 'validation message should be displayed if eagerValidate is true');
     }));
 
     s.test('eagerValidation', sync(function (t) {
@@ -205,18 +205,20 @@ suite('Utility Methods', function (s) {
     s.test('reset on view with intial value', sync(function (t) {
         view = new SelectView({
             name: 'word',
-            options: arr,
-            value: 'three',
+            options: [0, 1, 2],
+            value: 0,
             unselectedText: 'Please choose:'
         });
 
         var select = view.el.querySelector('select');
 
-        view.setValue('one');
-        t.equal(select.options[select.selectedIndex].value, 'one');
+        t.equal(view.value, 0);
+
+        view.setValue(2);
+        t.equal(select.options[select.selectedIndex].value, '2');
         
         view.reset();
-        t.equal(select.options[select.selectedIndex].value, 'three');
+        t.equal(view.value, 0);
     }));
 
     s.test('reset on view with no initial value', sync(function (t) {
@@ -231,24 +233,7 @@ suite('Utility Methods', function (s) {
         t.equal(select.options[select.selectedIndex].value, 'three');
 
         view.reset();
-        t.equal(select.options[select.selectedIndex].value, 'one');
-    }));
-
-    s.test('reset on view with `unselectedText` and no initial value', sync(function (t) {
-        view = new SelectView({
-            name: 'word',
-            options: arr,
-            unselectedText: 'Please choose:'
-        });
-
-        var select = view.el.querySelector('select');
-
-        view.setValue('one');
-        t.equal(select.options[select.selectedIndex].value, 'one');
-
-        view.reset();
-        t.equal(select.options[select.selectedIndex].value, '');
-        t.equal(select.options[select.selectedIndex].text, 'Please choose:');
+        t.equal(select.options[select.selectedIndex].value, 'three');
     }));
 
     s.test('beforeSubmit', sync(function (t) {
@@ -700,5 +685,4 @@ suite('With ampersand collection', function (s) {
         t.equal(optionNodes[3].disabled, false);
         t.equal(optionNodes[4].disabled, true);
     }));
-
 });

--- a/test/index.js
+++ b/test/index.js
@@ -92,6 +92,28 @@ suite('Setup', function (s) {
         t.equal(selectName, 'word');
     }));
 
+    s.test('message container', sync(function (t) {
+        view = new SelectView({
+            name: 'num',
+            options: fieldOptions.options,
+            eagerValidate: false,
+            required: true,
+            unselectedText: 'default'
+        });
+
+        t.ok(view.mContainer.style.display === 'none', 'validation message should be hidden if eagerValidate is false');
+
+        view = new SelectView({
+            name: 'num',
+            options: fieldOptions.options,
+            eagerValidate: true,
+            required: true,
+            unselectedText: 'default'
+        });
+
+        t.ok(view.mContainer.style.display !== 'none', 'validation message should be displayed if eagerValidate is true');
+    }));
+
     s.test('eagerValidation', sync(function (t) {
         view = new SelectView({
             name: 'num',

--- a/test/index.js
+++ b/test/index.js
@@ -202,7 +202,7 @@ suite('Utility Methods', function (s) {
         t.equal(view.valid, false);
     }));
 
-    s.test('reset on view with intial value', sync(function (t) {
+    s.test('reset on view with initial value', sync(function (t) {
         view = new SelectView({
             name: 'word',
             options: [0, 1, 2],
@@ -234,6 +234,7 @@ suite('Utility Methods', function (s) {
 
         view.reset();
         t.equal(select.options[select.selectedIndex].value, 'three');
+        t.equal(view.value, 'three');
     }));
 
     s.test('beforeSubmit', sync(function (t) {

--- a/test/index.js
+++ b/test/index.js
@@ -237,11 +237,12 @@ suite('Utility Methods', function (s) {
         t.equal(view.value, 'three');
     }));
 
-    s.test('beforeSubmit', sync(function (t) {
+    s.test('beforeSubmit with options', sync(function (t) {
         view = new SelectView({
             name: 'word',
             options: arr,
-            required: true
+            required: true,
+            idAttribute: 'someOtherKey'
         });
 
         var select = view.el.querySelector('select');
@@ -252,6 +253,85 @@ suite('Utility Methods', function (s) {
         view.beforeSubmit();
         t.equal(view.value, 'one');
         t.equal(view.valid, true);
+
+    }));
+
+    s.test('beforeSubmit with array options', sync(function (t) {
+        view = new SelectView({
+            name: 'word',
+            options: [ [0, 'Option Zero'], [1, 1, false], [1.5, 1.5, true] ],
+            required: true,
+            idAttribute: 'someOtherKey'
+        });
+
+        var select = view.el.querySelector('select');
+        t.equal(select.options[select.selectedIndex].text, 'Option Zero');
+
+        t.equal(view.valid, false);
+        t.equal(view.value, null);
+        view.beforeSubmit();
+        t.equal(view.value, 0);
+        t.equal(view.valid, true);
+
+    }));
+
+    s.test('beforeSubmit with collection and yieldModel: false', sync(function (t) {
+        coll = new Collection([
+            { id: 0, someOtherKey: 'zero', title: 'Option zero' },
+            { id: 1, someOtherKey: 'foo',  title: 'Option one' },
+            { id: 2, someOtherKey: 'bar',  title: 'Option two' },
+            { id: 3, someOtherKey: 'baz',  title: 'Option three' }
+        ]);
+
+        view = new SelectView({
+            name: 'word',
+            options: coll,
+            required: true,
+            yieldModel: false,
+            idAttribute: 'someOtherKey'
+        });
+
+        var select = view.el.querySelector('select');
+        t.equal(select.options[select.selectedIndex].value, 'zero');
+
+        t.equal(view.valid, false);
+        t.equal(view.value, null);
+        view.beforeSubmit();
+        t.equal(view.value, 'zero');
+        t.equal(view.valid, true);
+
+    }));
+
+
+    s.test('beforeSubmit with collection and yieldModel: true', sync(function (t) {
+        coll = new Collection([
+            { id: 0, someOtherKey: 'zero', title: 'Option zero' },
+            { id: 1, someOtherKey: 'foo',  title: 'Option one' },
+            { id: 2, someOtherKey: 'bar',  title: 'Option two' },
+            { id: 3, someOtherKey: 'baz',  title: 'Option three' }
+        ]);
+
+        view = new SelectView({
+            name: 'word',
+            options: coll,
+            required: true,
+            yieldModel: true,
+            idAttribute: 'someOtherKey'
+        });
+
+        var select = view.el.querySelector('select');
+        t.equal(select.options[select.selectedIndex].value, 'zero');
+
+        select.selectedIndex = 2;
+
+        t.equal(view.valid, false);
+        t.equal(view.value, null);
+        view.beforeSubmit();
+        t.deepEqual(view.value, coll.at(2));
+        t.equal(view.value.get('title'), 'Option two');
+        t.equal(view.value.get('id'), 2);
+        t.equal(view.valid, true);
+
     }));
 });
 

--- a/test/index.js
+++ b/test/index.js
@@ -106,6 +106,146 @@ suite('Setup', function (s) {
 
 });
 
+suite('Utility Methods', function (s) {
+    var arr = ['one', 'two', 'three'];
+    var view;
+
+    s.test('clear', sync(function (t) {
+        view = new SelectView({
+            name: 'word',
+            options: arr,
+            value: 'two'
+        });
+
+        var select = view.el.querySelector('select');
+
+        t.equal(select.options[select.selectedIndex].value, 'two');
+        view.clear();
+        t.equal(select.options[select.selectedIndex].value, 'one');
+    }));
+
+    s.test('clear on view with `unselectedText`', sync(function (t) {
+        view = new SelectView({
+            name: 'word',
+            options: arr,
+            unselectedText: 'Please choose:',
+            value: 'two',
+            required: false
+        });
+
+        var select = view.el.querySelector('select');
+
+        t.equal(select.options[select.selectedIndex].value, 'two');
+        view.clear();
+        t.equal(select.options[select.selectedIndex].value, '');
+        t.equal(select.options[select.selectedIndex].text, 'Please choose:');
+        view.validate();
+        t.equal(view.valid, true);
+    }));
+
+    s.test('clear on `required` view`', sync(function (t) {
+        view = new SelectView({
+            name: 'word',
+            options: arr,
+            value: 'two',
+            required: true
+        });
+
+        var select = view.el.querySelector('select');
+
+        t.equal(select.options[select.selectedIndex].value, 'two');
+        view.clear();
+        t.equal(select.options[select.selectedIndex].value, 'one');
+        t.equal(view.value, null);
+        view.validate();
+        t.equal(view.valid, false);
+    }));
+
+    s.test('clear on `required` view with `unselectedText`', sync(function (t) {
+        view = new SelectView({
+            name: 'word',
+            options: arr,
+            unselectedText: 'Please choose:',
+            value: 'two',
+            required: true
+        });
+
+        var select = view.el.querySelector('select');
+
+        t.equal(select.options[select.selectedIndex].value, 'two');
+        view.clear();
+        t.equal(select.options[select.selectedIndex].value, '');
+        t.equal(select.options[select.selectedIndex].text, 'Please choose:');
+        view.validate();
+        t.equal(view.valid, false);
+    }));
+
+    s.test('reset on view with intial value', sync(function (t) {
+        view = new SelectView({
+            name: 'word',
+            options: arr,
+            value: 'three',
+            unselectedText: 'Please choose:'
+        });
+
+        var select = view.el.querySelector('select');
+
+        view.setValue('one');
+        t.equal(select.options[select.selectedIndex].value, 'one');
+        
+        view.reset();
+        t.equal(select.options[select.selectedIndex].value, 'three');
+    }));
+
+    s.test('reset on view with no initial value', sync(function (t) {
+        view = new SelectView({
+            name: 'word',
+            options: arr
+        });
+
+        var select = view.el.querySelector('select');
+
+        view.setValue('three');
+        t.equal(select.options[select.selectedIndex].value, 'three');
+
+        view.reset();
+        t.equal(select.options[select.selectedIndex].value, 'one');
+    }));
+
+    s.test('reset on view with `unselectedText` and no initial value', sync(function (t) {
+        view = new SelectView({
+            name: 'word',
+            options: arr,
+            unselectedText: 'Please choose:'
+        });
+
+        var select = view.el.querySelector('select');
+
+        view.setValue('one');
+        t.equal(select.options[select.selectedIndex].value, 'one');
+
+        view.reset();
+        t.equal(select.options[select.selectedIndex].value, '');
+    }));
+
+    s.test('beforeSubmit', sync(function (t) {
+        view = new SelectView({
+            name: 'word',
+            options: arr,
+            required: true
+        });
+
+        var select = view.el.querySelector('select');
+        t.equal(select.options[select.selectedIndex].value, 'one');
+
+        t.equal(view.valid, false);
+        t.equal(view.value, null);
+        view.beforeSubmit();
+        t.equal(view.value, 'one');
+        t.equal(view.valid, true);
+    }));
+});
+
 suite('Options array with number items', function (s) {
     s.beforeEach(function () {
         arr = [0, 1, 1.5, 2];


### PR DESCRIPTION
1. Tests for `clear` method.
2. Added the `reset` method. Works as follows:

    * If a starting `value` is available reset to that.
    * If there is no starting `value` fall back to the first option. Note: This will be `unselectedText` if it is available or `null` if for some reason there are no options. Otherwise it's just the value of first option within the select element.

    @cdaringe I was going to fallback to `clear` here, however, it will result in an error if there isn't a `null` option available.  Is this the expected behaviour of `clear`?

3. Explicitly hide the message container on setup. Currently the validation message will be displayed on setup unless you hide it explicitly in your own code. Setup of the view should handle this. Tests included.

4. `beforeSubmit` method with test. Used by FormView.  Ensures the value of the selected option is set on the view when the form is submitted, triggering any validation.  See the related test for expected behaviour. 