### PR TITLE
Check for parentNode before invoking removeChild

### DIFF
--- a/ampersand-select-view.js
+++ b/ampersand-select-view.js
@@ -175,7 +175,7 @@ SelectView.prototype.updateSelectedOption = function () {
 };
 
 SelectView.prototype.remove = function () {
-    if (this.el) this.el.parentNode.removeChild(this.el);
+    if (this.el && this.el.parentNode) this.el.parentNode.removeChild(this.el);
     this.el.removeEventListener('change', this.onChange, false);
 };
 

--- a/test/index.js
+++ b/test/index.js
@@ -538,4 +538,36 @@ suite('With ampersand collection', function (s) {
         t.equal(optionNodes[4].disabled, true);
     }));
 
+    s.test('removes el from parent when remove is invoked', sync(function (t) {
+        t.plan(1);
+
+        var el = {
+            parentNode: {
+                removeChild: function (el) {
+                    t.equal(el, view.el);
+                }
+            },
+            removeEventListener: function() {}
+        };
+
+        view = new SelectView({
+            name: 'num',
+            options: arr
+        });
+        view.el = el;
+
+        view.remove();
+    }));
+
+    s.test('does not explode when el has no parent and remove is invoked', sync(function (t) {
+        view = new SelectView({
+            name: 'num',
+            options: arr
+        });
+
+        t.equal(view.el.parentNode, null);
+
+        view.remove();
+    }));
+
 });


### PR DESCRIPTION
Brings ampersand-select-view more in line with how [ampersand-view does it](https://github.com/AmpersandJS/ampersand-view/blob/21403d2a38771dd709b4282731637c6b19fc4175/ampersand-view.js#L148), otherwise you occasionally get `Uncaught TypeError: Cannot read property 'removeChild' of null`.