### PR TITLE
Add check for parent update method

### DIFF
--- a/ampersand-select-view.js
+++ b/ampersand-select-view.js
@@ -271,7 +271,7 @@ module.exports = View.extend({
         }
         this.validate(skipValidationMessage);
         if (this.select) this.updateSelectedOption();
-        if (this.parent) this.parent.update(this);
+        if (this.parent && typeof this.parent.update === 'function') this.parent.update(this);
         return this.value;
     },
 


### PR DESCRIPTION
When used as a view/subview there isn't an update method by default as there is with a form view.