### PR TITLE
support <optgroup> elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Sets the selected option to that which matches the provided value.  Updates the 
 - `name`: the `<select>`'s `name` attribute's value. Used when reporting to parent form
 - `parent`: parent form reference
 - `options`: array/collection of options to render into the select box
+- `[groupOptions]`: use instead of `options` to generate <optgroup> elements within your <select>. If this is set, any values passed in `options` will be ignored and replaced with values coming from `groupOptions`.
 - `[el]`: element if you want to render the view into
 - `[template]`: a custom template to use (see 'template' section, below, for more)
 - `[required]`: [default: `false`] field required

--- a/README.md
+++ b/README.md
@@ -160,9 +160,10 @@ module.exports = FormView.extend({
 [![testling badge](https://ci.testling.com/AmpersandJS/ampersand-select-view.png)](https://ci.testling.com/AmpersandJS/ampersand-select-view)
 
 ## changelog
+- 6.1.0
+    - Generate <optgroup> elements by passing the new `options.groupOptions` parameter
 - 6.0.0
     - Match field label rendering behavior to ampersand-input-view.  removes label fallback to `name` attr
-    - Generate <optgroup> elements by passing the new `options.groupOptions` parameter
     - Improve x-browser testing CI
 - 5.0.0
     - Change events now always get triggered on the select element instead of blindly calling on the root element.

--- a/README.md
+++ b/README.md
@@ -111,15 +111,15 @@ module.exports = FormView.extend({
                 name: 'option',
                 parent: this,
                 // define groupOptions to generate <optgroup> elements. Pass it an array of
-                // Objects, each object will become an <optgroup> with groupname being the
+                // Objects, each object will become an <optgroup> with groupName being the
                 // <optgroup>'s name and options being an array (either of strings or array, see
                 // previous two examples) that will become the <option>s under that <optgroup>
                 groupOptions: [ {
-                                  groupname: "Options 1",
+                                  groupName: "Options 1",
                                   options: [ ['1', 'Option 1'], ['2', 'Option 2'], ['3', 'Option 3', true] ]
                                 },
                                 {
-                                  groupname: "Options 2",
+                                  groupName: "Options 2",
                                   options: [ ['a', 'Option A'], ['b', 'Option B'], ['c', 'Option C', true] ]
                                 }
                               ],

--- a/README.md
+++ b/README.md
@@ -108,6 +108,23 @@ module.exports = FormView.extend({
                 options: [ ['a', 'Option A'], ['b', 'Option B'], ['c', 'Option C', true] ]
             }),
             new SelectView({
+                name: 'option',
+                parent: this,
+                // define groupOptions to generate <optgroup> elements. Pass it an array of
+                // Objects, each object will become an <optgroup> with groupname being the
+                // <optgroup>'s name and options being an array (either of strings or array, see
+                // previous two examples) that will become the <option>s under that <optgroup>
+                groupOptions: [ {
+                                  groupname: "Options 1",
+                                  options: [ ['1', 'Option 1'], ['2', 'Option 2'], ['3', 'Option 3', true] ]
+                                },
+                                {
+                                  groupname: "Options 2",
+                                  options: [ ['a', 'Option A'], ['b', 'Option B'], ['c', 'Option C', true] ]
+                                }
+                              ],
+            }),
+            new SelectView({
                 name: 'model',
                 parent: this,
                 // you can pass in a collection here too
@@ -143,8 +160,9 @@ module.exports = FormView.extend({
 
 ## changelog
 - 6.0.0
-    - match field label rendering behavior to ampersand-input-view.  removes label fallback to `name` attr
-    - improve x-browser testing CI
+    - Match field label rendering behavior to ampersand-input-view.  removes label fallback to `name` attr
+    - Generate <optgroup> elements by passing the new `options.groupOptions` parameter
+    - Improve x-browser testing CI
 - 5.0.0
     - Change events now always get triggered on the select element instead of blindly calling on the root element.
 - 4.0.0

--- a/ampersand-select-view.js
+++ b/ampersand-select-view.js
@@ -44,7 +44,7 @@ module.exports = View.extend({
 
         if (opts.groupOptions) {
             if (opts.options) {
-                console.warn("Warning: as ampersand-select-view was provided both options and groupOptions properties, option will be overwritten with values from groupOptions.");
+                //console.warn('Warning: as ampersand-select-view was provided both options and groupOptions properties, option will be overwritten with values from groupOptions.');
             }
             // Create the options array from the groupOptions property, containing
             // only the values that will result in an <option> element

--- a/ampersand-select-view.js
+++ b/ampersand-select-view.js
@@ -185,7 +185,7 @@ module.exports = View.extend({
         if (this.groupOptions) {
             this.groupOptions.forEach(function (optgroup) {
                 // this.groupOptions is an array of Objects representing <optgroup> elements
-                var optGroupElement = createOptgroup(optgroup.groupname);
+                var optGroupElement = createOptgroup(optgroup.groupName);
                 // Loop over the <options> from that <optgroup>
                 optgroup.options.forEach(function (option) {
                    // Add the <option>s to the <optgroup>

--- a/ampersand-select-view.js
+++ b/ampersand-select-view.js
@@ -57,7 +57,6 @@ module.exports = View.extend({
                 }.bind(this));
             }.bind(this));
         }
-        console.log(opts.options);
 
         if (!Array.isArray(opts.options) && !opts.options.isCollection) {
             throw new Error('SelectView requires select options.');

--- a/ampersand-select-view.js
+++ b/ampersand-select-view.js
@@ -44,7 +44,7 @@ module.exports = View.extend({
 
         if (opts.groupOptions) {
             if (opts.options) {
-                //console.warn('Warning: as ampersand-select-view was provided both options and groupOptions properties, option will be overwritten with values from groupOptions.');
+                throw new Error('Don\'t provide ampersand-select-view with both options and groupOptions properties, as option will be generated with values from groupOptions.');
             }
             // Create the options array from the groupOptions property, containing
             // only the values that will result in an <option> element

--- a/test/index.js
+++ b/test/index.js
@@ -577,7 +577,7 @@ suite('groupOptions to generate <optgroup> elements, with string items', functio
         view = null;
     });
 
-    s.test('groupOptions - renders the options into the select (array)', sync(function (t) {
+    s.test('groupOptions - string - renders the options into the select (array)', sync(function (t) {
         view = new SelectView({
             autoRender: true,
             name: 'word',
@@ -601,7 +601,7 @@ suite('groupOptions to generate <optgroup> elements, with string items', functio
         t.equal(optionNodes[3].textContent, 'Option 2.2');
     }));
 
-    s.test('groupOptions - renders the empty item', sync(function (t) {
+    s.test('groupOptions - string - renders the empty item', sync(function (t) {
         view = new SelectView({
             autoRender: true,
             name: 'word',
@@ -620,7 +620,7 @@ suite('groupOptions to generate <optgroup> elements, with string items', functio
         t.equal(optionNodes[1].textContent, 'Option 1.1');
     }));
 
-    s.test('groupOptions - selects the right item (options: [\'valAndText\'])', sync(function (t) {
+    s.test('groupOptions - string - selects the right item (options: [\'valAndText\'])', sync(function (t) {
         view = new SelectView({
             autoRender: true,
             name: 'word',
@@ -647,7 +647,7 @@ suite('groupOptions to generate <optgroup> elements, with string items', functio
         }
     }));
 
-    s.test('groupOptions - options are enabled', sync(function (t) {
+    s.test('groupOptions - string - options are enabled', sync(function (t) {
         view = new SelectView({
             autoRender: true,
             name: 'word',
@@ -662,7 +662,7 @@ suite('groupOptions to generate <optgroup> elements, with string items', functio
         t.equal(optionNodes[3].disabled, false);
     }));
 
-    s.test('groupOptions - options with empty string unselectedText', sync(function (t) {
+    s.test('groupOptions - string - options with empty string unselectedText', sync(function (t) {
         view = new SelectView({
             autoRender: true,
             name: 'emptyUnselectedTest',
@@ -682,6 +682,157 @@ suite('groupOptions to generate <optgroup> elements, with string items', functio
         );
     }));
 
+});
+
+suite('groupOptions to generate <optgroup> elements, with array items', function (s) {
+    s.beforeEach(function() {
+        arr = [ {
+                  groupName: 'Options 1',
+                  options: [ ['one', 'Option One'], ['two', 'Option Two', false], ['three', 'Option Three', true] ]
+                },
+                {
+                  groupName: 'Options 2',
+                  options: [ ['a', 'Option A'], ['b', 'Option B', false], ['c', 'Option C', true] ]
+                }
+              ];
+        arrNum = [ {
+                     groupName: 'Options 1',
+                     options: [ [0, 'Option Zero'], [1, 1, false], [1.5, 1.5, true] ]
+                   },
+                   {
+                     groupName: 'Options 2',
+                     options: [ ['a', 'Option A'], ['b', 'Option B', false], ['c', 'Option C', true] ]
+                   }
+                 ];
+        view = null;
+    });
+
+    s.test('groupOptions - array - renders the arr-num options into the select', sync(function (t) {
+        view = new SelectView({
+            autoRender: true,
+            name: 'num',
+            groupOptions: arrNum
+        });
+
+        var optionNodes = view.el.querySelectorAll('select option');
+
+        t.equal(optionNodes.length, 6);
+
+        t.equal(optionNodes[0].value, '0');
+        t.equal(optionNodes[0].textContent, 'Option Zero');
+
+        t.equal(optionNodes[1].value, '1');
+        t.equal(optionNodes[1].textContent, '1');
+
+        t.equal(optionNodes[2].value, '1.5');
+        t.equal(optionNodes[2].textContent, '1.5');
+        t.ok(optionNodes[2].disabled, true);
+
+        t.equal(optionNodes[3].value, 'a');
+        t.equal(optionNodes[3].textContent, 'Option A');
+
+        t.equal(optionNodes[4].value, 'b');
+        t.equal(optionNodes[4].textContent, 'Option B');
+
+        t.equal(optionNodes[5].value, 'c');
+        t.equal(optionNodes[5].textContent, 'Option C');
+        t.ok(optionNodes[5].disabled, true);
+    }));
+
+    s.test('groupOptions - array - renders the arr-str options into the select', sync(function (t) {
+        view = new SelectView({
+            autoRender: true,
+            name: 'word',
+            groupOptions: arr
+        });
+
+        var optionNodes = view.el.querySelectorAll('select option');
+
+        t.equal(optionNodes.length, 6);
+
+        t.equal(optionNodes[0].value, 'one');
+        t.equal(optionNodes[0].textContent, 'Option One');
+
+        t.equal(optionNodes[1].value, 'two');
+        t.equal(optionNodes[1].textContent, 'Option Two');
+
+        t.equal(optionNodes[2].value, 'three');
+        t.equal(optionNodes[2].textContent, 'Option Three');
+        t.ok(optionNodes[2].disabled, true);
+
+        t.equal(optionNodes[3].value, 'a');
+        t.equal(optionNodes[3].textContent, 'Option A');
+
+        t.equal(optionNodes[4].value, 'b');
+        t.equal(optionNodes[4].textContent, 'Option B');
+
+        t.equal(optionNodes[5].value, 'c');
+        t.equal(optionNodes[5].textContent, 'Option C');
+        t.ok(optionNodes[5].disabled, true);
+    }));
+
+    s.test('groupOptions - array - renders the empty item', sync(function (t) {
+        view = new SelectView({
+            autoRender: true,
+            name: 'word',
+            groupOptions: arr,
+            unselectedText: 'Please choose:'
+        });
+
+        var optionNodes = view.el.querySelectorAll('select option');
+
+        t.equal(optionNodes.length, 7);
+
+        t.equal(optionNodes[0].value, '', 'First option value should be empty string.');
+        t.equal(optionNodes[0].innerHTML, 'Please choose:', 'First option should have unselectedText');
+
+        t.equal(optionNodes[1].value, 'one');
+        t.equal(optionNodes[1].textContent, 'Option One');
+    }));
+
+    s.test('groupOptions - array - selects the right item (options:  [[\'val\', \'text\']])', sync(function (t) {
+        view = new SelectView({
+            autoRender: true,
+            name: 'word',
+            groupOptions: arr,
+            unselectedText: 'Please choose:',
+            value: 'two'
+        });
+
+        var select = view.el.querySelector('select');
+
+        t.equal(select.options[select.selectedIndex].value, 'two');
+
+        view.setValue(undefined);
+        t.equal(select.options[select.selectedIndex].innerHTML, 'Please choose:');
+
+        view.setValue('one');
+        t.equal(select.options[select.selectedIndex].value, 'one');
+
+        try {
+            view.setValue('totes-wrong');
+            t.ok(false, 'unable to set invalid option');
+        } catch(err) {
+            t.ok('unable to set invalid option');
+        }
+    }));
+
+    s.test('groupOptions - array - renders a disabled item if a third value is passed which is truthy', sync(function (t) {
+        view = new SelectView({
+            autoRender: true,
+            name: 'word',
+            groupOptions: arr,
+        });
+
+        var optionNodes = view.el.querySelectorAll('select option');
+
+        t.equal(optionNodes[0].disabled, false);
+        t.equal(optionNodes[1].disabled, false);
+        t.equal(optionNodes[2].disabled, true);
+        t.equal(optionNodes[3].disabled, false);
+        t.equal(optionNodes[4].disabled, false);
+        t.equal(optionNodes[5].disabled, true);
+    }));
 });
 
 suite('With ampersand collection', function (s) {

--- a/test/index.js
+++ b/test/index.js
@@ -38,7 +38,7 @@ var fieldOptions = {
     options: ['foo', 'bar', 'baz']
 };
 var view;
-var arr, arrNum;
+var arr, arrNum, options, groupOptions;
 var coll;
 
 viewConventions.view(suite.tape, SelectView, fieldOptions);
@@ -832,6 +832,25 @@ suite('groupOptions to generate <optgroup> elements, with array items', function
         t.equal(optionNodes[3].disabled, false);
         t.equal(optionNodes[4].disabled, false);
         t.equal(optionNodes[5].disabled, true);
+    }));
+});
+
+suite('Both options and groupOptions', function (s) {
+    s.beforeEach(function () {
+        options = ['one', 'two', 'three'];
+        groupOptions = [ {groupName: 'Options 1', options: ['Option 1.1', 'Option 1.2'] }, {groupName: 'Options 2', options: ['Option 2.1', 'Option 2.2'] } ];
+        view = null;
+    });
+
+    s.test('Error thrown when both options and groupOptions are provided', sync(function (t) {
+        t.throws(function () {
+          view = new SelectView({
+              autoRender: true,
+              name: 'word',
+              options: options,
+              groupOptions: groupOptions
+          });
+        });
     }));
 });
 

--- a/test/index.js
+++ b/test/index.js
@@ -571,6 +571,119 @@ suite('Options array with array items', function (s) {
     }));
 });
 
+suite('groupOptions to generate <optgroup> elements, with string items', function (s) {
+    s.beforeEach(function () {
+        arr = [ {groupName: 'Options 1', options: ['Option 1.1', 'Option 1.2'] }, {groupName: 'Options 2', options: ['Option 2.1', 'Option 2.2'] } ];
+        view = null;
+    });
+
+    s.test('groupOptions - renders the options into the select (array)', sync(function (t) {
+        view = new SelectView({
+            autoRender: true,
+            name: 'word',
+            groupOptions: arr
+        });
+
+        var optionNodes = view.el.querySelectorAll('select option');
+
+        t.equal(optionNodes.length, 4);
+
+        t.equal(optionNodes[0].value, 'Option 1.1');
+        t.equal(optionNodes[0].textContent, 'Option 1.1');
+
+        t.equal(optionNodes[1].value, 'Option 1.2');
+        t.equal(optionNodes[1].textContent, 'Option 1.2');
+
+        t.equal(optionNodes[2].value, 'Option 2.1');
+        t.equal(optionNodes[2].textContent, 'Option 2.1');
+
+        t.equal(optionNodes[3].value, 'Option 2.2');
+        t.equal(optionNodes[3].textContent, 'Option 2.2');
+    }));
+
+    s.test('groupOptions - renders the empty item', sync(function (t) {
+        view = new SelectView({
+            autoRender: true,
+            name: 'word',
+            groupOptions: arr,
+            unselectedText: 'Please choose:'
+        });
+
+        var optionNodes = view.el.querySelectorAll('select option');
+
+        t.equal(optionNodes.length, 5);
+
+        t.equal(optionNodes[0].value, '', 'First option value should be empty string.');
+        t.equal(optionNodes[0].innerHTML, 'Please choose:', 'First option should have unselectedText');
+
+        t.equal(optionNodes[1].value, 'Option 1.1');
+        t.equal(optionNodes[1].textContent, 'Option 1.1');
+    }));
+
+    s.test('groupOptions - selects the right item (options: [\'valAndText\'])', sync(function (t) {
+        view = new SelectView({
+            autoRender: true,
+            name: 'word',
+            groupOptions: arr,
+            unselectedText: 'Please choose:',
+            value: 'Option 1.2'
+        });
+
+        var select = view.el.querySelector('select');
+
+        t.equal(select.options[select.selectedIndex].value, 'Option 1.2');
+
+        view.setValue(undefined);
+        t.equal(select.options[select.selectedIndex].innerHTML, 'Please choose:');
+
+        view.setValue('Option 1.1');
+        t.equal(select.options[select.selectedIndex].value, 'Option 1.1');
+
+        try {
+            view.setValue('invalid-option');
+            t.ok(false, 'unable to set invalid option');
+        } catch (err) {
+            t.ok(true, 'unable to set invalid option');
+        }
+    }));
+
+    s.test('groupOptions - options are enabled', sync(function (t) {
+        view = new SelectView({
+            autoRender: true,
+            name: 'word',
+            groupOptions: arr,
+            unselectedText: 'Please choose:',
+            value: 'Option 1.2'
+        });
+        var optionNodes = view.el.querySelectorAll('select option');
+        t.equal(optionNodes[0].disabled, false);
+        t.equal(optionNodes[1].disabled, false);
+        t.equal(optionNodes[2].disabled, false);
+        t.equal(optionNodes[3].disabled, false);
+    }));
+
+    s.test('groupOptions - options with empty string unselectedText', sync(function (t) {
+        view = new SelectView({
+            autoRender: true,
+            name: 'emptyUnselectedTest',
+            groupOptions: arr,
+            unselectedText: '',
+            required: true,
+            requiredMessage: 'emptyUnselectedTest'
+        });
+        var select = view.el.querySelector('select');
+        t.equal(select.options[select.selectedIndex].innerHTML, '', 'rendered unselectedText is `\'\'`');
+        view.beforeSubmit();
+        var msgText = view.queryByHook('message-text').innerHTML;
+        t.equal(
+            msgText,
+            'emptyUnselectedTest',
+            'required value <select> w/ empty unselectedText prompts submit validation'
+        );
+    }));
+
+});
+
 suite('With ampersand collection', function (s) {
     s.beforeEach(function() {
         view = null;


### PR DESCRIPTION
Fixes #61 

Because the `options` parameter is not only used to render the `<select>` but also to perform other tasks such as in `updateSelectedOption` or `getOptionByValue`, I've created a new `groupOptions` parameter which will be used to create the various `<optgroup>` elements at rendering time, and from which the `options` parameter will be created that contains only the values that appear in `<options>` elements. That way, the rest of the features work just the same as if just `options` was passed.

I have not created any tests, as I'm not sure how to run them. Help would be appreciated here.

You can try different values of `groupOptions`:

simple (just text `options`):
`groupOptions: [ {groupname: "Options 1", options: ["Option 1.1", "Option 1.2"] }, {groupname: "Options 2", options: ["Option 2.1", "Option 2.2"] } ]`

or more complex (with arrays as `options` to define different values and disable some elements):
```
groupOptions: [ {
                  groupname: "Options 1",
                  options: [ ['1', 'Option 1'], ['2', 'Option 2'], ['3', 'Option 3', true] ]
                },
                {
                  groupname: "Options 2",
                  options: [ ['a', 'Option A'], ['b', 'Option B'], ['c', 'Option C', true] ]
                }
              ]
```