### PR TITLE
Added support for number type attributes

### DIFF
--- a/ampersand-select-view.js
+++ b/ampersand-select-view.js
@@ -359,15 +359,20 @@ module.exports = View.extend({
             if (!model) throw new Error('model or model idAttribute not found in options collection');
             return this.yieldModel ? model : model[this.idAttribute];
         } else if (Array.isArray(this.options)) {
-            // find value value in options array
-            // find option, formatted [['val', 'text'], ...]
-            if (this.options.length && Array.isArray(this.options[0])) {
+            if (this.options.length) {
                 for (var i = this.options.length - 1; i >= 0; i--) {
-                    if (this.options[i][0] == value) return this.options[i];
+                    var option = this.options[i];
+                    // find value in collection as [['val','text'], ...]
+                    if (Array.isArray(option) && option[0] == value) {
+                        return option[0];
+                    // find value in collection as ['val', ...]
+                    } else if (option == value) {
+                        return option;
+                    }
                 }
+            } else {
+                throw new Error('no options provided');
             }
-            // find option, formatted ['valAndText', ...] format
-            if (this.options.length && this.options.indexOf(value) !== -1) return value;
             throw new Error('value not in set of provided options');
         }
         throw new Error('select option set invalid');


### PR DESCRIPTION
This change will allow model attributes with type 'number' to work with the select view. As an added bonus, this will also allow for mixed option sets (i.e. `[[0,'First'], 2, 3, [4,'Fourth'], 5, ...]`).