### PR TITLE
Update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,18 +9,18 @@
   "dependencies": {
     "ampersand-dom": "^1.1.0",
     "ampersand-version": "^1.0.1",
-    "ampersand-view": "^9.0.0",
     "domify": "^1.2.2",
+    "ampersand-view": "^10.0.1",
     "matches-selector": "^1.0.0"
   },
   "devDependencies": {
-    "ampersand-collection": "^1.3.1",
-    "ampersand-form-view": "^3.1.0",
-    "ampersand-state": "^4.4.5",
     "ampersand-view-conventions": "^1.1.1",
     "function-bind": "^1.0.2",
     "jshint": "^2.9.1",
-    "phantomjs": "^1.9.19",
+    "ampersand-collection": "^2.0.0",
+    "ampersand-form-view": "^7.0.0",
+    "ampersand-state": "^5.0.2",
+    "phantomjs-prebuilt": "^2.1.12",
     "precommit-hook": "^3.0.0",
     "tape": "^4.4.0",
     "tape-suite": "^0.2.1",


### PR DESCRIPTION
ampersand-view is now 10 (this upgrades lodash to use v4);

devsDeps with major releases, including phantomjs-prebuilt (née phantomjs), have been upgraded;

function-bind was removed as phantomsjs v2 supports bind